### PR TITLE
Fix some issues when setting up from scratch

### DIFF
--- a/util/01__setup/download_and_update_tools.sh
+++ b/util/01__setup/download_and_update_tools.sh
@@ -699,6 +699,7 @@ if [ -f "${DIST_BOOTSTRAP_ICONS}" ]; then
 	echo "[INFO] 'Bootstrap Icons' (${BOOTSTRAP_ICONS_VERSION}) is already available"
 else
 	BOOTSTRAP_ICONS_ZIP="${DIST_STATIC}/bootstrap-icons-${BOOTSTRAP_ICONS_VERSION}.zip"
+	mkdir -p "${DIST_STATIC}/css" "${DIST_STATIC}/fonts"
 	find "${SCRIPT_PATH}/../../dist/templating/static/css" -type f -iname 'bootstrap-icons-*.css' -delete
 	find "${SCRIPT_PATH}/../../dist/templating/static/fonts" -type f -iname 'bootstrap-icons.*' -delete
 	simple_check_and_download "Bootstrap Icons" "templating/static/bootstrap-icons-${BOOTSTRAP_ICONS_VERSION}.zip" "https://github.com/twbs/icons/releases/download/v${BOOTSTRAP_ICONS_VERSION}/bootstrap-icons-${BOOTSTRAP_ICONS_VERSION}.zip" "${BOOTSTRAP_ICONS_VERSION}"
@@ -714,6 +715,7 @@ fi
 # Images, Logos, Favicon, Fonts, Scripts
 ##############################################################################################################
 
+mkdir -p "${DIST_STATIC}/img/"
 simple_check_and_download "Favicon - VMware" "templating/static/img/favicon.ico" 'https://www.vmware.com/favicon.ico' "latest"
 
 simple_check_and_download "Logo - CSA" "templating/static/img/csa.svg" 'https://raw.githubusercontent.com/vmware-tanzu/cloud-suitability-analyzer/master/csa-app/frontend/src/assets/csa-icon.svg' "latest"
@@ -722,7 +724,6 @@ simple_check_and_download "Logo - FSB" "templating/static/img/fsb.png" 'https://
 if [ -f "${DIST_STATIC}/img/github.svg" ]; then
 	echo "[INFO] 'Logo - GitHub' (latest) is already available"
 else
-	mkdir -p "${DIST_STATIC}/img/"
 	simple_check_and_download "Logo - GitHub" "templating/static/img/github-mark.zip" 'https://github.githubassets.com/images/modules/logos_page/github-mark.zip' "latest"
 	pushd "${DIST_STATIC}/img/" &>/dev/null
 	unzip github-mark.zip &>/dev/null

--- a/util/01__setup/download_and_update_tools.sh
+++ b/util/01__setup/download_and_update_tools.sh
@@ -623,7 +623,7 @@ DIST_TRIVY="${DIST_DIR}/oci__trivy_${TRIVY_VERSION}.img"
 if [[ "${UPDATE_VULN_DBS}" == "true" ]]; then
 	# Remove current image to force an update of the cache
 	find "${SCRIPT_PATH}/../../dist/" -type f -iname 'oci__trivy_*.img' -delete
-	${CONTAINER_ENGINE} rmi -f $(${CONTAINER_ENGINE} images 'trivy' -a -q)
+	${CONTAINER_ENGINE} images -a | grep 'trivy' | awk '{print $3}' | xargs ${CONTAINER_ENGINE} rmi --force
 fi
 if [ -f "${DIST_TRIVY}" ]; then
 	echo "[INFO] 'Trivy' (${DIST_TRIVY}) is already available"

--- a/util/01__setup/download_and_update_tools.sh
+++ b/util/01__setup/download_and_update_tools.sh
@@ -74,7 +74,7 @@ function simple_check_and_download() {
 	fi
 }
 
-function remove_container_image() {
+function remove_container_images() {
   NAME="${1}"
   ${CONTAINER_ENGINE} images -a | grep "${NAME}" | awk '{print $3}' | xargs "${CONTAINER_ENGINE}" rmi --force
 }
@@ -92,7 +92,7 @@ function download_container_image() {
 		# Delete previous versions
 		IMAGE_INAME=$(echo "${LOCAL_IMG}" | rev | cut -d '_' -f 2- | rev | sed 's/$/_*.img/')
 		find "${DIST_DIR}" -type f -iname "${IMAGE_INAME}" -delete
-		remove_container_image "${REPO}"
+		remove_container_images "${REPO}"
 		${CONTAINER_ENGINE} pull --platform "${PLATFORM}" "${REPO}:${VERSION}"
 		${CONTAINER_ENGINE} image save "${REPO}:${VERSION}" | gzip >"${DIST_DIR}/${LOCAL_IMG}"
 	fi
@@ -406,7 +406,7 @@ else
 
 	exec 6>/dev/null
 	# Remove existing and build Scancode container image
-	remove_container_image "scancode-toolkit"
+	remove_container_images "scancode-toolkit"
 
 	mkdir -p "${DIST_DIR}/containerized/scancode-toolkit"
 
@@ -628,7 +628,7 @@ DIST_TRIVY="${DIST_DIR}/oci__trivy_${TRIVY_VERSION}.img"
 if [[ "${UPDATE_VULN_DBS}" == "true" ]]; then
 	# Remove current image to force an update of the cache
 	find "${SCRIPT_PATH}/../../dist/" -type f -iname 'oci__trivy_*.img' -delete
-	remove_container_image "trivy"
+	remove_container_images "trivy"
 fi
 if [ -f "${DIST_TRIVY}" ]; then
 	echo "[INFO] 'Trivy' (${DIST_TRIVY}) is already available"


### PR DESCRIPTION
If you run `audit setup` or `audit download` on a machine where Auditor was never been used before (that is, `dist` folder is not yet populated and no Auditor-related Docker images has been fetched) the procedure fails.

This PR fixes those issues by creating a couple required folders and fixing the way `trivy` Docker image is being removed.