### PR TITLE
Upgrade JDK used to build Bagger and Fernflower to version 20

### DIFF
--- a/_shared_functions.sh
+++ b/_shared_functions.sh
@@ -101,6 +101,14 @@ function log_console_success() {
 	echo -e "${GREEN}    [SUCCESS] ${*}${N}"
 }
 
+function stream_edit() {
+	if [[ "${IS_MAC}" == "true" ]]; then
+		sed -i '' -e "${1}" "${2}"
+	else
+		sed -i -e "${1}" "${2}"
+	fi
+}
+
 function for_each_group() {
 	while read -r DIR; do
 		GROUP_NAME="$(basename "${DIR}")"

--- a/_versions.sh
+++ b/_versions.sh
@@ -7,7 +7,10 @@
 ##############################################################################################################
 
 # Java version used for Bagger and Fernflower
-export JAVA_VERSION='17'
+export JAVA_VERSION='20'
+
+# Gradle version for Fernflower
+export GRADLE_VERSION='8.3'
 
 # Current version of Application Portfolio Auditor
 export TOOL_VERSION='2.0.0'

--- a/_versions.sh
+++ b/_versions.sh
@@ -6,14 +6,11 @@
 # Library tracking versions of all used tools and frameworks.
 ##############################################################################################################
 
-# Java version used for Bagger and Fernflower
-export JAVA_VERSION='20'
-
-# Gradle version for Fernflower
-export GRADLE_VERSION='8.3'
-
 # Current version of Application Portfolio Auditor
 export TOOL_VERSION='2.0.0'
+
+# Java version used for Bagger and Fernflower
+export JAVA_VERSION='20'
 
 # List of the versions for all tools in use.
 

--- a/util/01__setup/download_and_update_tools.sh
+++ b/util/01__setup/download_and_update_tools.sh
@@ -17,6 +17,9 @@ UPDATE_VULN_DBS=true
 ## curl -fsSL 'https://mcr.microsoft.com/v2/dotnet/runtime/tags/list' |grep 'alpine'| grep -v 'preview' | grep -v 'amd64'|grep -v 'arm' |sort|tail -1|tr -d ' ,"'
 DOTNET_RUNTIME_TAG="mcr.microsoft.com/dotnet/runtime:7.0.9-alpine3.18"
 
+# Gradle version for Fernflower
+GRADLE_VERSION='8.3'
+
 # ------ Do not modify
 [[ "$DEBUG" == "true" ]] && set -x
 set -eu
@@ -37,21 +40,19 @@ export DOCKER_PLATFORM="linux/${DOCKER_ARCH}"
 ## Multiple platform build currently not supported
 # export DOCKER_PLATFORM="linux/amd64,linux/arm64"
 
-NORMAL='\033[0m'
-BLUE='\033[1;34m'
-RED='\033[0;31m'
-ORANGE='\033[0;33m'
+# shellcheck disable=SC1091
+source "${CURRENT_DIR}/_shared_functions.sh"
 
 function log_tool_info() {
-	echo -e "\n${BLUE}${*}${NORMAL}"
+	echo -e "\n${BLUE}${*}${N}"
 }
 
 function log_error() {
-	echo -e "${RED}${*}${NORMAL}"
+	echo -e "${RED}${*}${N}"
 }
 
 function log_warn() {
-	echo -e "${ORANGE}${*}${NORMAL}"
+	echo -e "${ORANGE}${*}${N}"
 }
 
 function simple_check_and_download() {
@@ -180,17 +181,12 @@ else
 
 	# Selectively checkout sub directory
 	git sparse-checkout set plugins/java-decompiler/engine
-	#git checkout HEAD -- plugins/java-decompiler/engine/
 	cd plugins/java-decompiler/engine
 
 	# Build Fernflower using the configured $JAVA_VERSION
-	if [[ "${IS_MAC}" == "true" ]]; then
-	  SED="sed -i ''"
-	else
-	  SED="sed -i"
-	fi
-	${SED} " s/targetCompatibility '.*'/targetCompatibility '${JAVA_VERSION}'/" build.gradle
-  ${SED} " s/distributionUrl=.*/distributionUrl=https\\\:\/\/services.gradle.org\/distributions\/gradle-${GRADLE_VERSION}-bin.zip/" gradle/wrapper/gradle-wrapper.properties
+	stream_edit "s/targetCompatibility '.*'/targetCompatibility '${JAVA_VERSION}'/" build.gradle
+	stream_edit 's|distributionUrl=.*|distributionUrl=https\://services.gradle.org/distributions/gradle-'"${GRADLE_VERSION}"'-bin.zip|' 'gradle/wrapper/gradle-wrapper.properties'
+	./gradlew wrapper
 	GRADLE_OPTS="-Dorg.gradle.daemon=false" ./gradlew assemble
 	popd &>/dev/null
 
@@ -665,7 +661,6 @@ log_tool_info "99 - Static content"
 JS_DIR="${DIST_DIR}/templating/static/js"
 mkdir -p "${JS_DIR}"
 
-#set -x
 find "${SCRIPT_PATH}/../../dist/templating/static/js" -type f -iname 'd3.v*.min.js' ! -name d3.v4.min.js ! -name d3.v${D3_VERSION}.min.js -delete
 simple_check_and_download "JavaScript - D3.js" "templating/static/js/d3.v4.min.js" 'https://unpkg.com/d3@4.13.0/build/d3.min.js' "4.13.0"
 simple_check_and_download "JavaScript - D3.js" "templating/static/js/d3.v${D3_VERSION}.min.js" "https://unpkg.com/d3@${D3_VERSION}/dist/d3.min.js" "${D3_VERSION}"

--- a/util/01__setup/download_and_update_tools.sh
+++ b/util/01__setup/download_and_update_tools.sh
@@ -183,7 +183,14 @@ else
 	#git checkout HEAD -- plugins/java-decompiler/engine/
 	cd plugins/java-decompiler/engine
 
-	# Build Fernflower
+	# Build Fernflower using the configured $JAVA_VERSION
+	if [[ "${IS_MAC}" == "true" ]]; then
+	  SED="sed -i ''"
+	else
+	  SED="sed -i"
+	fi
+	${SED} " s/targetCompatibility '.*'/targetCompatibility '${JAVA_VERSION}'/" build.gradle
+  ${SED} " s/distributionUrl=.*/distributionUrl=https\\\:\/\/services.gradle.org\/distributions\/gradle-${GRADLE_VERSION}-bin.zip/" gradle/wrapper/gradle-wrapper.properties
 	GRADLE_OPTS="-Dorg.gradle.daemon=false" ./gradlew assemble
 	popd &>/dev/null
 


### PR DESCRIPTION
This PR changes the JDK version used to build Fernflower and Bagger to 20, aligning it to the version installed in the setup phase.

There are also some adjustments in Fernflower gradle files, because current latest version targets Java 17 and uses a gradle version not supporting Java 20.