### PR TITLE
Improve function to re-generate reports

### DIFF
--- a/00__check_prereqs.sh
+++ b/00__check_prereqs.sh
@@ -153,8 +153,16 @@ if [[ "${SKIP_TARGET_GROUP_ANALYSIS}" == "false" ]]; then
 			ARE_PREREQUISITES_MET=false
 		fi
 	else
-		log_console_error "Specified application group ('${TARGET_GROUP}') not found. Please use the import option or organize your applications as described in README.md."
-		ARE_PREREQUISITES_MET=false
+		if [[ -f "${REPORTS_DIR}/list__${TARGET_GROUP}__all_apps.csv" ]]; then
+			log_console_warning "Applications do not exist locally. Creating mock application group structure under '${SELECTED_APP_DIR_IN}'"
+			mkdir -p "${SELECTED_APP_DIR_IN}"
+			while read -r APP; do
+				touch "${SELECTED_APP_DIR_IN}/${APP}"
+			done < <(cut -d ',' -f 1 "${REPORTS_DIR}/list__${TARGET_GROUP}__all_apps.csv")
+		else
+			log_console_error "Specified application group ('${TARGET_GROUP}') not found. Please use the import option or organize your applications as described in README.md."
+			ARE_PREREQUISITES_MET=false
+		fi
 	fi
 fi
 

--- a/97__generate_reports.sh
+++ b/97__generate_reports.sh
@@ -643,11 +643,11 @@ function generate_trivy_html() {
 		['jfrog.com']='JFrog'
 		['jolokia.org']=Jolokia
 		['jvn.jp']='JVN'
-		['kb.cert.org']='CERT/CC'
 	)
 
 	# shellcheck disable=SC2034
 	declare -A URL_PATTERN_MAP_4=(
+		['kb.cert.org']='CERT/CC'
 		['lunasec']=LunaSec
 		['mageia']='Mageia'
 		['mandriva']='Mandriva'
@@ -657,11 +657,11 @@ function generate_trivy_html() {
 		['mitre']=MITRE
 		['netapp']=NetApp
 		['nist']=NIST
-		['nu11secur1ty']='Nu11Secur1ty'
 	)
 
 	# shellcheck disable=SC2034
 	declare -A URL_PATTERN_MAP_5=(
+		['nu11secur1ty']='Nu11Secur1ty'
 		['openjdk']='OpenJDK'
 		['opensuse']=Suse
 		['openwall']=Openwall
@@ -670,12 +670,13 @@ function generate_trivy_html() {
 		['pivotal.io']='Pivotal'
 		['praetorian']='Praetorian'
 		['redhat']='Red Hat'
-		['seclists']=SecLists
-		['secunia']='Secunia'
+		['rockylinux']='Rocky Linux'
 	)
 
 	# shellcheck disable=SC2034
 	declare -A URL_PATTERN_MAP_6=(
+		['seclists']=SecLists
+		['secunia']='Secunia'
 		['secpod.org']='SecPod'
 		['securityfocus']='BugTraq'
 		['securitytracker']='Security Tracker'
@@ -684,12 +685,12 @@ function generate_trivy_html() {
 		['snyk.io']=Snyk
 		['sonicwall']=SonicWall
 		['spring.io']='Spring'
-		['springsource']='Spring'
-		['sun.com']='Sun'
 	)
 
 	# shellcheck disable=SC2034
 	declare -A URL_PATTERN_MAP_7=(
+		['springsource']='Spring'
+		['sun.com']='Sun'
 		['suse.com']='Suse'
 		['tenable']=Tenable
 		['trustwave']='Trustwave'

--- a/98__generate_timeline.sh
+++ b/98__generate_timeline.sh
@@ -52,7 +52,7 @@ function main() {
 	export TIMELINE_JSON="${REPORTS_DIR}/98__timeline.json"
 	export TIMELINE_JSON_TMP="${REPORTS_DIR}/timeline.json.tmp"
 
-	if [[ -f "${TIMELINE_LOG}" ]] && [[ ! -f "${INFO_REPORT}" ]]; then
+	if [[ -f "${TIMELINE_LOG}" ]]; then
 
 		# Get the first group
 		APP_GROUP=$(find "${APP_DIR_IN}" -maxdepth 1 -mindepth 1 -type d -print -quit)


### PR DESCRIPTION
Extend "./audit -r" functionality to create a mock application structure and re-generate reports while not having the applications locally.